### PR TITLE
Add ability to add trunk to dial target

### DIFF
--- a/src/nodes/jambonz.html
+++ b/src/nodes/jambonz.html
@@ -364,7 +364,7 @@
       color: '#bbabaa',
       defaults: {
         name: {value: ''},
-        targets:{value:[{type: 'phone', dest: '', user: '', pass: '', varType: 'str'}]},
+        targets:{value:[{type: 'phone', dest: '', user: '', pass: '', varType: 'str', trunk: ''}]},
         headers: {value: []},
         actionhook: {value: ''},
         actionhookType: {value: 'str'},
@@ -502,6 +502,7 @@
             var row2 = $('<div/>',{style:"display:flex;margin-top:8px;"}).appendTo(fragment);
             var row3 = $('<div/>',{style:"margin-top:8px;"}).appendTo(fragment);
             var row4 = $('<div/>',{style:"display:flex;margin-top:8px;"}).appendTo(fragment);
+            var row5 = $('<div/>',{style:"margin-top:8px;"}).appendTo(fragment);
 
             var selectField = $('<select/>',{class:"node-input-target-type",style:"width:110px; margin-right:10px;"})
               .appendTo(row1);
@@ -531,6 +532,16 @@
               placeholder: '(if required by remote endpoint)'
             })
               .appendTo(row3);
+
+            $('<label style="padding-top:8px; padding-right:20px">Trunk:</label>')
+              .appendTo(row5);
+
+            $('<input/>',{
+              class:"node-input-target-property-trunk",
+              type:"text",
+              placeholder: 'Specify the name of the trunk used for this outbound call'
+            })
+              .appendTo(row5);
             
             selectField.on('change', function() {
               var type = $(this).val();
@@ -559,6 +570,12 @@
                 row2.show();
                 row3.show();
               }
+
+              if(type !== 'phone') {
+                row5.hide();
+              } else {
+                row5.show();
+              }
             });
             selectField.val(target.type);
             propertyName.typedInput('value', target.dest);
@@ -567,10 +584,13 @@
             var datafield = row1.find('.node-input-target-property-name');
             var userfield = row2.find('.node-input-target-property-authuser');
             var passfield = row3.find('.node-input-target-property-authpassword');
+            var trunkfield = row5.find('.node-input-target-property-trunk');
 
             datafield.typedInput('type', target.varType);
 
             switch (target.type) {
+              case 'phone':
+                trunkfield.val(target.trunk);
               case 'sip': 
                 userfield.val(target.user);
                 passfield.val(target.pass);
@@ -591,6 +611,7 @@
             dest: '',
             user: '',
             pass: '',
+            trunk: '',
             varType: 'str'
           }
           this.targets = [target];
@@ -660,6 +681,7 @@
           var dest    = target.find('.node-input-target-property-name').typedInput('value');
           var user = target.find('.node-input-target-property-authuser').val();
           var pass = target.find('.node-input-target-property-authpassword').val();
+          var trunk = target.find('.node-input-target-property-trunk').val();
           if (!['phone', 'user', 'sip', 'teams'].includes(type) || 0 === dest.length) return;
 
           var t = {
@@ -669,6 +691,9 @@
           };
           if ('sip' === type && user.length > 0 && pass.length > 0) {
             Object.assign(t, {user, pass});
+          }
+          if ('phone' === type && trunk.length > 0) {
+            t.trunk = trunk;
           }
           node.targets.push(t);
         });


### PR DESCRIPTION
This pull request adds the ability to add the missing 'trunk' property to dial targets of type 'phone' on the dial node as illustrated in the screenshot below.

![image](https://user-images.githubusercontent.com/7524012/199227881-0f12c9d0-8ed8-4271-bea9-aa2227ee6cfe.png)

