### PR TITLE
add mustache to say and gather

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,3 @@ node_modules
 .DS_Store
 
 .vscode
-package copy.json

--- a/src/nodes/gather.html
+++ b/src/nodes/gather.html
@@ -315,6 +315,10 @@
   
     <h3>Details</h3>
     The gather command is used to collect dtmf or speech input.
+
+    Within the text field you can use mustache syntax to insert properties of the msg, flow or global objects.
+    For example if you wanted to insert the value of msg.payload into the text you could put
+    <code>The payload is {{msg.payload}}</code>
     <h3>References</h3>
       <ul>
           <li><a href="https://docs.jambonz.org/jambonz/#gather">Jambonz gather reference</a></li>

--- a/src/nodes/libs.js
+++ b/src/nodes/libs.js
@@ -71,7 +71,8 @@ exports.appendVerb = (msg, obj) => {
       }
       return '${' + b + '}';
     });
-    return newString;
+    data = {'global' : glob, 'flow' : flow, 'msg' : msg}
+    return mustache.render(newString, data);
   }
   
 

--- a/src/nodes/say.html
+++ b/src/nodes/say.html
@@ -109,6 +109,10 @@
   <h3>Details</h3>
   The say command is used to send synthesized speech to the remote party. 
   The text provided may be either plain text or may use SSML tags.
+  
+  Within the text field you can use mustache syntax to insert properties of the msg, flow or global objects.
+  For example if you wanted to insert the value of msg.payload into the text you could put
+  <code>The payload is {{msg.payload}}</code>
   <h3>References</h3>
     <ul>
         <li><a href="https://docs.jambonz.org/jambonz/#say">Jambonz say reference</a></li>


### PR DESCRIPTION
This PR adds support for Mustache templating to the text fields in the say and gather nodes.
It also adds details to the help text for those nodes.

The original literals support is still there but I have not documented that as this form of templating feels like a more node-red ish way of doing things, the literal support is purely for backwards compatibliity.

I've not updated the version number in the package for this PR 