### PR TITLE
support old hangup configuration

### DIFF
--- a/src/nodes/hangup.js
+++ b/src/nodes/hangup.js
@@ -10,9 +10,11 @@ module.exports = function(RED) {
           };
           // headers
           var headers = {};
-          config.headers.forEach(function(h) {
-            if (h.h.length && h.v.length) headers[h.h] = h.v;
-          });
+          if (config.headers) {
+            config.headers.forEach(function(h) {
+              if (h.h.length && h.v.length) headers[h.h] = h.v;
+            });
+          }
           Object.assign(data, {headers});
           appendVerb(msg, data);
           node.log(`hangup jambonz: ${JSON.stringify(msg.jambonz)}`);


### PR DESCRIPTION
It seems like Node-RED does not update hangup configuration if the node was installed on older version.