### PR TITLE
Add support for priority and call sid in queue nodes

### DIFF
--- a/src/nodes/dequeue.html
+++ b/src/nodes/dequeue.html
@@ -7,6 +7,8 @@
         name: {value: ''},
         queue: {required: true, value: ''},
         queueType: {value: 'str'},
+        callSid: {value: ''},
+        callSidType: {value: 'str'},
         actionHook: {},
         actionHookType: {value: 'str'},
         confirmHook: {},
@@ -25,6 +27,10 @@
         $('#node-input-queue').typedInput({
           types: ['str', 'msg', 'flow', 'global', 'jsonata', 'env'],
           typeField: $('#node-input-queueType')
+        });
+        $('#node-input-callSid').typedInput({
+          types: ['str', 'msg', 'flow', 'global'],
+          typeField: $('#node-input-callSidType')
         });
         $('#node-input-actionHook').typedInput({
           types: ['str', 'msg', 'flow', 'global', 'jsonata', 'env'],
@@ -54,6 +60,11 @@
       <input type="hidden" id="node-input-queueType">
     </div>
     <div class="form-row">
+      <label for="node-input-callSid">Call Sid</label>
+      <input type="text" id="node-input-callSid" placeholder="sid of the call">
+      <input type="hidden" id="node-input-callSidType">
+    </div>
+    <div class="form-row">
       <label for="node-input-beep">Play beep on connecting</label>
       <input type="checkbox" id="node-input-beep">
     </div>
@@ -79,6 +90,7 @@
     <p>removes the a call from the front of a queue and bridges that call to the current caller.</p>
     <h3>Properties</h3>
     <p><code>Queue name</code> -  Name of the queue.</p>
+    <p><code>Call Sid</code> -  An optional parameter to specify which call to dequeue.</p>
     <p><code>Play beep on connecting</code> -  Play a beep tone to this caller only just prior to connecting the queued call.</p>
     <p><code>Action hook</code> - A webhook invoke when call ends.</p>
     <p><code>Confirm hook</code> - A webhook for an application to run on the callee's end before the call is bridged.</p>

--- a/src/nodes/dequeue.js
+++ b/src/nodes/dequeue.js
@@ -9,6 +9,7 @@ module.exports = function(RED) {
       appendVerb(msg, {
         verb: 'dequeue',
         name:  v_resolve(config.queue, config.queueType, this.context(), msg),
+        callSid: v_resolve(config.callSid, config.callSidType, this.context(), msg),
         beep: config.beep,
         actionHook: v_resolve(config.actionHook, config.actionHookType, this.context(), msg),
         confirmHook: v_resolve(config.confirmHook, config.confirmHookType, this.context(), msg),

--- a/src/nodes/enqueue.html
+++ b/src/nodes/enqueue.html
@@ -7,6 +7,8 @@
         name: {value: ''},
         queue: {required: true, value: ''},
         queueType: {value: 'str'},
+        priority: {value: 999},
+        priorityType: {value: 'num'},
         actionHook: {},
         actionHookType: {value: 'str'},
         waitHook: {},
@@ -22,6 +24,10 @@
         $('#node-input-queue').typedInput({
           types: ['str', 'msg', 'flow', 'global', 'jsonata', 'env'],
           typeField: $('#node-input-queueType')
+        });
+        $('#node-input-priority').typedInput({
+          types: ['num', 'msg', 'flow', 'global'],
+          typeField: $('#node-input-priorityType')
         });
         $('#node-input-actionHook').typedInput({
           types: ['str', 'msg', 'flow', 'global', 'jsonata', 'env'],
@@ -47,6 +53,11 @@
       <input type="hidden" id="node-input-queueType">
     </div>
     <div class="form-row">
+      <label for="node-input-priority">Priority</label>
+      <input type="text" id="node-input-priority" placeholder="caller priority">
+      <input type="hidden" id="node-input-priorityType">
+    </div>
+    <div class="form-row">
       <label for="node-input-actionHook">Action hook</label>
       <input type="text" id="node-input-actionHook" placeholder="webhook url">
       <input type="hidden" id="node-input-actionHookType">
@@ -64,6 +75,8 @@
     <h3>Properties</h3>
       <p><code>Queue name</code> - 
         The name of the queue</p>
+      <p><code>Priority</code> - 
+        The priority for which the call will be added to the queue. Must be a non-negative value and defaults to 999 (low-priority) if not set.</p>
       <p><code>Action hook</code> - 
         A webhook invoke when operation completes.</p>
       <p><code>Wait hook</code> - 

--- a/src/nodes/enqueue.js
+++ b/src/nodes/enqueue.js
@@ -6,9 +6,12 @@ module.exports = function(RED) {
     RED.nodes.createNode(this, config);
     var node = this;
     node.on('input', function(msg, send, done) {
+      const priorityValue = v_resolve(config.priority, config.priorityType, this.context(), msg);
+
       appendVerb(msg, {
         verb: 'enqueue',
         name:  v_resolve(config.queue, config.queueType, this.context(), msg),
+        priority:  (/^\d+$/.test(priorityValue)) ? parseInt(priorityValue) : null,
         actionHook: v_resolve(config.actionHook, config.actionHookType, this.context(), msg),
         waitHook: v_resolve(config.waitHook, config.waitHookType, this.context(), msg)
       });


### PR DESCRIPTION
This pull request in preparation of another pull request in jambonz-feature-server that adds additional parameters to queuing. (jambonz/jambonz-feature-server#357). After merging this pull request the following changes will be added:

- A priority field is added to the enqueue node which only allows positive digits (and 0), otherwise it won't get set.
- A call sid field is added to the dequeue node.