### PR TITLE
remove default value

### DIFF
--- a/src/nodes/sip-refer.html
+++ b/src/nodes/sip-refer.html
@@ -15,7 +15,7 @@
         referToType: {value: 'str'},
         referredBy: {value: ''},
         referredByType: {value: 'str'},
-        headers: {value: '{}'},
+        headers: {value: ''},
         headersType: {value: 'json'},
         eventHook: {value: ''},
         eventHookType: {value: 'str'},


### PR DESCRIPTION
Small change that removes the default empty json object so as the display the placeholder text, the default value isn't needed as empty values are removed from the verb