### PR TITLE
get-call node added

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
       "create sms": "src/nodes/create_sms.js",
       "lcc": "src/nodes/lcc.js",
       "get_alerts": "src/nodes/get_alerts.js",
+      "get_call": "src/nodes/get_call.js",
       "get_calls": "src/nodes/get_calls.js",
       "get_recent_calls": "src/nodes/get_recent_calls.js"
     }

--- a/src/nodes/get_call.html
+++ b/src/nodes/get_call.html
@@ -1,0 +1,57 @@
+<!-- Javascript -->
+<script type="text/javascript">
+  var mustacheType = {
+    value: 'mustache',
+    label: 'mustache',
+    hasvalue: true,
+    icon: 'resources/@jambonz/node-red-contrib-jambonz/icons/mustache.svg'
+  }
+  RED.nodes.registerType('get_call', {
+      category: 'jambonz',
+      color: '#aebfb9',
+      defaults: {
+        name: {value: ''},
+        server: {value: '', required: true, type: 'jambonz_auth'},
+        callSid: {value: '', validate: function(v) {
+          return v.length > 0;
+        }},
+        callSidType:{value: 'str'},
+      },
+      inputs: 1,
+      outputs: 1,
+      icon: "font-awesome/fa-cubes",
+      paletteLabel: "Get - Call",
+      label: function() { return this.name || 'Get Call';},
+      oneditprepare: () => {
+        $('#node-input-callSid').typedInput({
+          types: ['str','msg', 'flow', 'global', 'jsonata', 'env', mustacheType],
+          typeField: $('#node-input-callSidType')
+        });
+      }
+  });
+</script>
+
+<!-- HTML -->
+<script type="text/html" data-template-name="get_call">
+        <div class="form-row">
+          <label for="node-input-name"><i class="icon-tag"></i> Name</label>
+          <input type="text" id="node-input-name" placeholder="Name">
+        </div>
+        <div class="form-row">
+          <label for="node-input-server">Server</label>
+          <input type="text" id="node-input-server">
+        </div> 
+        <div class="form-row">
+          <label for="node-input-callSid">CallSid</label>
+          <input type="text" id="node-input-callSid">
+          <input type="hidden" id="node-input-callSidType">
+        </div>
+</script>
+
+<!-- Help Text -->
+<script type="text/html" data-help-name="get_call">
+      <p>Get call</p>
+
+      <h3>Details</h3>
+      Retrieve info for a single call under an account.
+</script>

--- a/src/nodes/get_call.js
+++ b/src/nodes/get_call.js
@@ -1,0 +1,45 @@
+const bent = require("bent");
+var { new_resolve} = require("./libs");
+
+module.exports = function (RED) {
+  function get_call(config) {
+    RED.nodes.createNode(this, config);
+    var node = this;
+    const server = RED.nodes.getNode(config.server);
+    const { accountSid, apiToken } = server.credentials;
+    node.on("input", async (msg, send, done) => {
+      const callSid = new_resolve(RED, config.callSid, config.callSidType, node, msg);
+      if (!callSid) {
+        if (done) done(new Error('CallSid empty'));
+          else node.error(new Error('CallSid empty'), msg);
+        return;
+      }
+      const req = bent(
+        `${server.url}/v1/Accounts/${accountSid}/Calls/${callSid}`,
+        'GET',
+        'json',
+        {
+          Authorization: `Bearer ${apiToken}`,
+        }
+      );
+      try {
+        const res = await req();
+        msg.payload = res;
+      } catch (err) {
+        if (err.statusCode) {
+          node.error(`GetCall failed with ${err.statusCode}`);
+          msg.statusCode = err.statusCode;
+        } else {
+          node.error(`Error getting call info ${JSON.stringify(err)}`);
+          if (done) done(err);
+          else node.error(err, msg);
+          send(msg);
+          return;
+        }
+      }
+      send(msg);
+      if (done) done();
+    });
+  }
+  RED.nodes.registerType("get_call", get_call);
+};


### PR DESCRIPTION
New `get-call` node added to get a single call info by `CallSid`. 

Uses https://github.com/jambonz/jambonz-api-server/blob/f3d002cfcaf8c05441d2df12a92ad9ae35a5174b/lib/routes/api/accounts.js#L852