### PR TITLE
Extended Gather node configuration properties

### DIFF
--- a/src/nodes/gather.html
+++ b/src/nodes/gather.html
@@ -13,10 +13,15 @@
         name: {value: ''},
         actionhook: {value: ''},
         actionhookType: {val: 'str'},
+        partialresulthook: {value: ''},
+        partialresulthookType: {val: 'str'},
         finishonkey: {value: ''},
         dtmfinput: {value: 0},
         speechinput: {value: 1},
         numdigits: {value: ''},
+        mindigits: {value: ''},
+        maxdigits: {value: ''},
+        interdigittimeout: {value: ''},
         timeout: {value: ''},
         bargein: {value: true},
         dtmfbargein: {value: true},
@@ -71,6 +76,10 @@
         $('#node-input-actionhook').typedInput({
           types: ['str', 'msg', 'flow', 'global', 'jsonata', 'env', mustacheType],
           typeField: $('#node-input-actionhookType')
+        });
+        $('#node-input-partialresulthook').typedInput({
+          types: ['str', 'msg', 'flow', 'global', 'jsonata', 'env', mustacheType],
+          typeField: $('#node-input-partialresulthookType')
         });
         $('#node-input-playurl').typedInput({
           types: ['str', 'msg', 'flow', 'global', 'jsonata', 'env', mustacheType],
@@ -137,6 +146,11 @@
     <label for="node-input-actionhook"><i class="icon-tag"></i> Action hook</label>
     <input type="text" id="node-input-actionhook" placeholder="webhook with results of gather">
     <input type="hidden" id="node-input-actionhookType">
+  </div>
+  <div class="form-row">
+    <label for="node-input-partialresulthook"><i class="icon-tag"></i> Partial result hook</label>
+    <input type="text" id="node-input-partialresulthook" placeholder="webhook with interim transcription results of gather">
+    <input type="hidden" id="node-input-partialresulthookType">
   </div>
   <fieldset>
     <legend>Prompt</legend>
@@ -217,6 +231,18 @@
       <div class="form-row">
         <label for="node-input-numdigits"><i class="icon-tag"></i> Num. digits</label>
         <input type="text" id="node-input-numdigits" placeholder="number of digits to collect">
+      </div>
+      <div class="form-row">
+        <label for="node-input-mindigits"><i class="icon-tag"></i> Min. digits</label>
+        <input type="text" id="node-input-mindigits" placeholder="Minimum number of dtmf digits expected to gather">
+      </div>
+      <div class="form-row">
+        <label for="node-input-maxdigits"><i class="icon-tag"></i> Max. digits</label>
+        <input type="text" id="node-input-maxdigits" placeholder="Maximum number of dtmf digits expected to gather">
+      </div>
+      <div class="form-row">
+        <label for="node-input-interdigittimeout"><i class="icon-tag"></i> Inter digit timeout</label>
+        <input type="text" id="node-input-interdigittimeout" placeholder="Amount of time to wait between digits after minDigits have been entered">
       </div>
       <div class="form-row">
         <label for="node-input-numtimeout"><i class="icon-tag"></i> Timeout</label>

--- a/src/nodes/gather.js
+++ b/src/nodes/gather.js
@@ -12,6 +12,7 @@ module.exports = function(RED) {
 
       var obj = {verb: 'gather', input: []};
       if (config.actionhook) obj.actionHook = new_resolve(RED, config.actionhook, config.actionhookType, node, msg)
+      if (config.partialresulthook) obj.partialResultHook = new_resolve(RED, config.partialresulthook, config.partialresulthookType, node, msg)
 
       // input
       if (config.speechinput) {
@@ -53,6 +54,10 @@ module.exports = function(RED) {
         if (config.finishonkey && config.finishonkey.length) obj.finishOnKey = config.finishonkey;
         if (/^\d+$/.test(config.numdigits)) obj.numDigits = parseInt(config.numdigits);
         if (/^\d+$/.test(config.timeout)) obj.timeout = parseInt(config.timeout);
+        if (/^\d+$/.test(config.mindigits)) obj.minDigits = parseInt(config.mindigits);
+        if (/^\d+$/.test(config.maxdigits)) obj.maxDigits = parseInt(config.maxdigits);
+        if (/^\d+$/.test(config.interdigittimeout)) obj.interDigitTimeout = parseInt(config.interdigittimeout);
+
         if (config.dtmfbargein) obj.dtmfBargein = config.dtmfbargein;
       }
 


### PR DESCRIPTION
This pull request adds additional properties to the Gather node that are currently supported by gather verb but not yet available on the node.  After merging this pull request the following changes will be added:

- A  Partial result hook field has been added to the gather node which allows the following input types 'str', 'msg', 'flow', 'global', 'jsonata', 'env', 'mustache'. If this field is left empty, it won't be set.
- A min. digits field is added to the gather node which only allows positive digits (and 0), otherwise it won't get set. This field will only be available if the 'accept dtmf input' checkbox is checked.
- A max. digits field is added to the gather node which only allows positive digits (and 0), otherwise it won't get set. This field will only be available if the 'accept dtmf input' checkbox is checked.
- A inter digit timeout field is added to the gather node which only allows positive digits (and 0), otherwise it won't get set. This field will only be available if the 'accept dtmf input' checkbox is checked.