### PR TITLE
Update the options in the user-auth node

### DIFF
--- a/src/nodes/libs.js
+++ b/src/nodes/libs.js
@@ -49,6 +49,7 @@ exports.appendVerb = (msg, obj) => {
     if (!val || !valtype) return val;
     switch (valtype) {
       case 'str': 
+      case 'bool':
       case 'num': 
       case 'env':  
       case 'msg': 

--- a/src/nodes/userauth.html
+++ b/src/nodes/userauth.html
@@ -17,10 +17,14 @@ RED.nodes.registerType('user auth',{
         ha1Type: {},
         expires: {value: ''},
         expiresType: {},
-        callHook: {value: ''},
-        callHookType: {},
-        callStatusHook: {value: ''},
-        callStatusHookType: {},
+        application: {value: ''},
+        applicationType: {},
+        directUser: {value: ''},
+        directUserType: {},
+        directApp: {value: ''},
+        directAppType: {},
+        directQueue: {value: ''},
+        directQueueType: {},
       },
       inputs:1,
       outputs:1,
@@ -39,13 +43,21 @@ RED.nodes.registerType('user auth',{
           types: ['str', 'msg', 'flow', 'global', 'jsonata', 'env', mustacheType],
           typeField: $('#node-input-expiresType')
         });
-        $('#node-input-callHook').typedInput({
+        $('#node-input-application').typedInput({
           types: ['str', 'msg', 'flow', 'global', 'jsonata', 'env', mustacheType],
-          typeField: $('#node-input-callHookType')
+          typeField: $('#node-input-applicationType')
         });
-        $('#node-input-callStatusHook').typedInput({
-          types: ['str', 'msg', 'flow', 'global', 'jsonata', 'env', mustacheType],
-          typeField: $('#node-input-callStatusHookType')
+        $('#node-input-directUser').typedInput({
+          types: ['bool', 'msg', 'flow', 'global', 'jsonata', 'env', mustacheType],
+          typeField: $('#node-input-directUserType')
+        });
+        $('#node-input-directApp').typedInput({
+          types: ['bool', 'msg', 'flow', 'global', 'jsonata', 'env', mustacheType],
+          typeField: $('#node-input-directAppType')
+        });
+        $('#node-input-directQueue').typedInput({
+          types: ['bool', 'msg', 'flow', 'global', 'jsonata', 'env', mustacheType],
+          typeField: $('#node-input-directQueueType')
         });
       }
   });
@@ -77,14 +89,24 @@ RED.nodes.registerType('user auth',{
         <input type="hidden" id="node-input-expiresType">
       </div>
       <div class="form-row">
-        <label for="node-input-callHook">Call hook</label>
-        <input type="text" id="node-input-callHook">
-        <input type="hidden" id="node-input-callHookType">
+        <label for="node-input-application">Default Application</label>
+        <input type="text" id="node-input-application">
+        <input type="hidden" id="node-input-applicationType">
       </div>
       <div class="form-row">
-        <label for="node-input-callStatusHook">Call status hook</label>
-        <input type="text" id="node-input-callStatusHook">
-        <input type="hidden" id="node-input-callStatusHookType">
+        <label for="node-input-directUser">Allow direct calling to other users</label>
+        <input type="text" id="node-input-directUser">
+        <input type="hidden" id="node-input-directUserType">
+      </div>
+      <div class="form-row">
+        <label for="node-input-directApp">Allow direct calling to applications</label>
+        <input type="text" id="node-input-directApp">
+        <input type="hidden" id="node-input-directAppType">
+      </div>
+      <div class="form-row">
+        <label for="node-input-directQueue">Allow direct calling to queues</label>
+        <input type="text" id="node-input-directQueue">
+        <input type="hidden" id="node-input-directQueueType">
       </div>
     </fieldset>
   </script>

--- a/src/nodes/userauth.js
+++ b/src/nodes/userauth.js
@@ -7,6 +7,8 @@ module.exports = function(RED) {
       RED.nodes.createNode(this, config);
       var node = this;
       node.on('input', function(msg) {
+        console.log(config.directUser)
+        console.log(config.directUserType)
         var attemptedAuthentication = false;
         var auth = msg.authRequest;
         var authResponse = {};
@@ -56,13 +58,18 @@ module.exports = function(RED) {
                 grantedExpires = Math.min(auth.expires, expires);
               }
             }
-            const callHook = new_resolve(RED, config.callHook, config.callHookType, node, msg);
-            const callStatusHook = new_resolve(RED, config.callStatusHook, config.callStatusHookType, node, msg);
+            const application = new_resolve(RED, config.application, config.applicationType, node, msg);
+            const directUser = new_resolve(RED, config.directUser, config.directUserType, node, msg);
+            const directApp = new_resolve(RED, config.directApp, config.directAppType, node, msg);
+            const directQueue = new_resolve(RED, config.directQueue, config.directQueueType, node, msg);
+            console.log(directUser)
             Object.assign(authResponse, {
               status: 'ok',
               expires: grantedExpires != null ? grantedExpires : null,
-              call_hook: callHook || null,
-              call_status_hook: callStatusHook || null,
+              application_sid: application || null,
+              allow_direct_user_calling: directUser,
+              allow_direct_app_calling: directApp,
+              allow_direct_queue_calling: directQueue,
             });
             Object.keys(authResponse).forEach((k) => authResponse[k] == null && delete authResponse[k]);
           }


### PR DESCRIPTION
This PR removes the redundant call-hook and call-status values from the User Auth node and replaces them with application_sid and the new bool controls for direct user|app|queue calling in https://github.com/jambonz/sbc-sip-sidecar/issues/45