### PR TITLE
Callback for evaluateNodeProperty method

### DIFF
--- a/src/nodes/conference.js
+++ b/src/nodes/conference.js
@@ -5,17 +5,17 @@ module.exports = function(RED) {
   function conference(config) {
     RED.nodes.createNode(this, config);
     var node = this;
-    node.on('input', function(msg) {
-      var statusHook = new_resolve(RED, config.statusHook, config.statusHookType, node, msg);
+    node.on('input', async function(msg) {
+      var statusHook = await new_resolve(RED, config.statusHook, config.statusHookType, node, msg);
       appendVerb(msg, {
         verb: 'conference',
-        name: new_resolve(RED, config.conference, config.conferenceType, node, msg),
-        enterHook: new_resolve(RED, config.enterHook, config.enterHookType, node, msg),
-        waitHook: new_resolve(RED, config.waitHook, config.waitHookType, node, msg),
-        actionHook: new_resolve(RED, config.actionHook, config.actionHookType, node, msg),
+        name: await new_resolve(RED, config.conference, config.conferenceType, node, msg),
+        enterHook: await new_resolve(RED, config.enterHook, config.enterHookType, node, msg),
+        waitHook: await new_resolve(RED, config.waitHook, config.waitHookType, node, msg),
+        actionHook: await new_resolve(RED, config.actionHook, config.actionHookType, node, msg),
         statusHook,
         ...(statusHook && { statusEvents: ['start', 'end', 'join', 'leave'] }),
-        maxParticipants: new_resolve(RED, config.maxParticipants, config.maxParticipantsType, node, msg),
+        maxParticipants: await new_resolve(RED, config.maxParticipants, config.maxParticipantsType, node, msg),
         beep: config.beep,
         startConferenceOnEnter: config.startConferenceOnEnter,
         endConferenceOnExit: config.endConferenceOnExit,

--- a/src/nodes/config.js
+++ b/src/nodes/config.js
@@ -4,7 +4,7 @@ module.exports = function(RED) {
     function cfg(config) {
         RED.nodes.createNode(this, config);
         var node = this;
-        node.on('input', function(msg) {
+        node.on('input', async function(msg) {
           obj = { verb: 'config' }
           if (config.tts){
             Object.assign(obj, {
@@ -23,9 +23,9 @@ module.exports = function(RED) {
               }
             })
             if (config.transcriptionvendor == 'google'){
-              obj.recognizer.hints = new_resolve(RED, config.transcriptionhints, config.transcriptionhintsType, node, msg)
-              obj.recognizer.altLanguages = [new_resolve(RED, config.altLanguages, config.altLanguagesType, node, msg)]
-              obj.recognizer.naicsCode = new_resolve(RED, config.naics, config.naicsType, node, msg)
+              obj.recognizer.hints = await new_resolve(RED, config.transcriptionhints, config.transcriptionhintsType, node, msg)
+              obj.recognizer.altLanguages = [await new_resolve(RED, config.altLanguages, config.altLanguagesType, node, msg)]
+              obj.recognizer.naicsCode = await new_resolve(RED, config.naics, config.naicsType, node, msg)
             }
             if (config.transcriptionvendor == 'aws'){
               obj.recognizer.vocabularyName = config.vocabularyname
@@ -37,36 +37,36 @@ module.exports = function(RED) {
           if (config.bargeIn){
             obj.bargeIn = {}
             config.bargeIn_enable != '' ? obj.bargeIn.enable = config.bargeIn_enable : null
-            config.bargeIn_actionHook != '' ? obj.bargeIn.actionHook = new_resolve(RED, config.bargeIn_actionHook, config.bargeIn_actionHookType, node, msg) : null
+            config.bargeIn_actionHook != '' ? obj.bargeIn.actionHook = await new_resolve(RED, config.bargeIn_actionHook, config.bargeIn_actionHookType, node, msg) : null
             config.bargeIn_input != '' ? obj.bargeIn.input = config.bargeIn_input.split(',') : null
-            config.bargeIn_finishOnKey != '' ? obj.bargeIn.finishOnKey = new_resolve(RED, config.bargeIn_finishOnKey, config.bargeIn_finishOnKeyType, node, msg) : null
-            config.bargeIn_numDigits != '' ? obj.bargeIn.numDigits = new_resolve(RED, config.bargeIn_numDigits, config.bargeIn_numDigitsType, node, msg) : null
-            config.bargeIn_minDigits != '' ? obj.bargeIn.minDigits = new_resolve(RED, config.bargeIn_minDigits, config.bargeIn_minDigitsType, node, msg) : null
-            config.bargeIn_maxDigits != '' ? obj.bargeIn.maxDigits = new_resolve(RED, config.bargeIn_maxDigits, config.bargeIn_maxDigitsType, node, msg) : null
-            config.bargeIn_interDigitTimeout != '' ? obj.bargeIn.interDigitTimeout = new_resolve(RED, config.bargeIn_interDigitTimeout, config.bargeIn_interDigitTimeoutType, node, msg) : null
+            config.bargeIn_finishOnKey != '' ? obj.bargeIn.finishOnKey = await new_resolve(RED, config.bargeIn_finishOnKey, config.bargeIn_finishOnKeyType, node, msg) : null
+            config.bargeIn_numDigits != '' ? obj.bargeIn.numDigits = await new_resolve(RED, config.bargeIn_numDigits, config.bargeIn_numDigitsType, node, msg) : null
+            config.bargeIn_minDigits != '' ? obj.bargeIn.minDigits = await new_resolve(RED, config.bargeIn_minDigits, config.bargeIn_minDigitsType, node, msg) : null
+            config.bargeIn_maxDigits != '' ? obj.bargeIn.maxDigits = await new_resolve(RED, config.bargeIn_maxDigits, config.bargeIn_maxDigitsType, node, msg) : null
+            config.bargeIn_interDigitTimeout != '' ? obj.bargeIn.interDigitTimeout = await new_resolve(RED, config.bargeIn_interDigitTimeout, config.bargeIn_interDigitTimeoutType, node, msg) : null
           }
 
           if (config.amd){
             obj.amd = {timers : {}}
-            config.amd_actionHook != '' ? obj.amd.actionHook = new_resolve(RED, config.amd_actionHook, config.amd_actionHookType, node, msg) : null
-            config.amd_thresholdWordCount != '' ? obj.amd.thresholdWordCount = new_resolve(RED, config.amd_thresholdWordCount, config.amd_thresholdWordCountType, node, msg) : null
-            config.amd_timers_noSpeechTimeoutMs != '' ? obj.amd.timers.noSpeechTimeoutMs = new_resolve(RED, config.amd_timers_noSpeechTimeoutMs, config.amd_timers_noSpeechTimeoutMsType, node, msg) : null
-            config.amd_timers_decisionTimeoutMs != '' ? obj.amd.timers.decisionTimeoutMs = new_resolve(RED, config.amd_timers_decisionTimeoutMs, config.amd_timers_decisionTimeoutMsType, node, msg) : null
-            config.amd_timers_toneTimeoutMs != '' ?	 obj.amd.timers.toneTimeoutMs = new_resolve(RED, config.amd_timers_toneTimeoutMs, config.amd_timers_toneTimeoutMsType, node, msg) : null
-            config.amd_timers_greetingCompletionTimeoutMs != '' ? obj.amd.timers.greetingCompletionTimeoutMs = new_resolve(RED, config.amd_timers_greetingCompletionTimeoutMs, config.amd_timers_greetingCompletionTimeoutMsType, node, msg) : null
+            config.amd_actionHook != '' ? obj.amd.actionHook = await new_resolve(RED, config.amd_actionHook, config.amd_actionHookType, node, msg) : null
+            config.amd_thresholdWordCount != '' ? obj.amd.thresholdWordCount = await new_resolve(RED, config.amd_thresholdWordCount, config.amd_thresholdWordCountType, node, msg) : null
+            config.amd_timers_noSpeechTimeoutMs != '' ? obj.amd.timers.noSpeechTimeoutMs = await new_resolve(RED, config.amd_timers_noSpeechTimeoutMs, config.amd_timers_noSpeechTimeoutMsType, node, msg) : null
+            config.amd_timers_decisionTimeoutMs != '' ? obj.amd.timers.decisionTimeoutMs = await new_resolve(RED, config.amd_timers_decisionTimeoutMs, config.amd_timers_decisionTimeoutMsType, node, msg) : null
+            config.amd_timers_toneTimeoutMs != '' ?	 obj.amd.timers.toneTimeoutMs = await new_resolve(RED, config.amd_timers_toneTimeoutMs, config.amd_timers_toneTimeoutMsType, node, msg) : null
+            config.amd_timers_greetingCompletionTimeoutMs != '' ? obj.amd.timers.greetingCompletionTimeoutMs = await new_resolve(RED, config.amd_timers_greetingCompletionTimeoutMs, config.amd_timers_greetingCompletionTimeoutMsType, node, msg) : null
           }
 
           if (config.record){
             obj.record = {}
             config.record_action != '' ? obj.record.action = config.record_action : null //TODO if multiple, split into array
-            config.record_siprecServerURL != '' ? obj.record.siprecServerURL = new_resolve(RED, config.record_siprecServerURL, config.record_siprecServerURLType, node, msg) : null
-            config.record_recordingID != '' ? obj.record.recordingID = new_resolve(RED, config.record_recordingID, config.record_recordingIDType, node, msg) : null
+            config.record_siprecServerURL != '' ? obj.record.siprecServerURL = await new_resolve(RED, config.record_siprecServerURL, config.record_siprecServerURLType, node, msg) : null
+            config.record_recordingID != '' ? obj.record.recordingID = await new_resolve(RED, config.record_recordingID, config.record_recordingIDType, node, msg) : null
           }
 
           if (config.listenRequest) {
             obj.listen = {}
-            const authUser = new_resolve(RED, config.listenAuthUser, config.listenAuthUserType, node, msg);
-            const authPass = new_resolve(RED, config.listenAuthPass, config.listenAuthPassType, node, msg);
+            const authUser = await new_resolve(RED, config.listenAuthUser, config.listenAuthUserType, node, msg);
+            const authPass = await new_resolve(RED, config.listenAuthPass, config.listenAuthPassType, node, msg);
             if (authUser && authPass) {
               obj.listen.wsAuth = {
                 username: authUser,
@@ -76,23 +76,23 @@ module.exports = function(RED) {
             obj.listen.enable = config.listenEnabled;
             obj.listen.sampleRate = +config.listenSampleRate;
             obj.listen.mixType = config.listenMixType;
-            config.url != '' ? obj.listen.url = new_resolve(RED, config.listenUrl, config.listenUrlType, node, msg) : null;
-            config.listenMetadata != '' ? obj.listen.metadata = new_resolve(RED, config.listenMetadata, config.listenMetadataType, node, msg) : null;
+            config.url != '' ? obj.listen.url = await new_resolve(RED, config.listenUrl, config.listenUrlType, node, msg) : null;
+            config.listenMetadata != '' ? obj.listen.metadata = await new_resolve(RED, config.listenMetadata, config.listenMetadataType, node, msg) : null;
             if (!Object.keys(obj.listen.metadata).length) {
               delete obj.listen.metadata;
             }
           }
 
           if (config.sipRequest) {
-            config.sipRequestWithinDialogHook != '' ? obj.sipRequestWithinDialogHook = new_resolve(RED, config.sipRequestWithinDialogHook, config.sipRequestWithinDialogHookType, node, msg) : null;
+            config.sipRequestWithinDialogHook != '' ? obj.sipRequestWithinDialogHook = await new_resolve(RED, config.sipRequestWithinDialogHook, config.sipRequestWithinDialogHookType, node, msg) : null;
           }
 
           if (config.onHold) {
-            config.onHoldMusic != '' ? obj.onHoldMusic = new_resolve(RED, config.onHoldMusic, config.onHoldMusicType, node, msg) : null;
+            config.onHoldMusic != '' ? obj.onHoldMusic = await new_resolve(RED, config.onHoldMusic, config.onHoldMusicType, node, msg) : null;
           }
 
           if (config.boostAudioSignal) {
-            config.boostAudioSignal != '' ? obj.boostAudioSignal = new_resolve(RED, config.boostAudioSignalLevel, config.boostAudioSignalLevelType, node, msg) : null;
+            config.boostAudioSignal != '' ? obj.boostAudioSignal = await new_resolve(RED, config.boostAudioSignalLevel, config.boostAudioSignalLevelType, node, msg) : null;
           }
           appendVerb(msg,  obj);
           node.send(msg);

--- a/src/nodes/create_call.js
+++ b/src/nodes/create_call.js
@@ -7,7 +7,7 @@ module.exports = function(RED) {
     var node = this;
     const server = RED.nodes.getNode(config.server);
 
-    node.on('input', async(msg, send, done) => {
+    node.on('input', async (msg, send, done) => {
       send = send || function() { node.send.apply(node, arguments);};
 
       const {accountSid, apiToken} = server.credentials;
@@ -19,9 +19,9 @@ module.exports = function(RED) {
         return;
       }
 
-      var from = new_resolve(RED, config.from, config.fromType, node, msg);
-      var to = new_resolve(RED, config.to, config.toType, node, msg);
-      var tag = new_resolve(RED, config.tag, config.tagType, node, msg);
+      var from = await new_resolve(RED, config.from, config.fromType, node, msg);
+      var to = await new_resolve(RED, config.to, config.toType, node, msg);
+      var tag = await new_resolve(RED, config.tag, config.tagType, node, msg);
 
       const opts = {
         from,
@@ -40,7 +40,7 @@ module.exports = function(RED) {
       }
 
       if (config.callername) {
-        opts.callerName = new_resolve(RED, config.callername, config.callernameType, node, msg);
+        opts.callerName = await new_resolve(RED, config.callername, config.callernameType, node, msg);
       }
 
       switch (config.mode) {
@@ -49,11 +49,11 @@ module.exports = function(RED) {
           break
         case 'url':
           opts.call_hook = {
-            url:  new_resolve(RED, config.call_hook_url, config.call_hook_urlType, node, msg),
+            url:  await new_resolve(RED, config.call_hook_url, config.call_hook_urlType, node, msg),
             method: config.call_hook_method
           };
           opts.call_status_hook = {
-            url: new_resolve(RED, config.call_status_url, config.call_status_urlType, node, msg),
+            url: await new_resolve(RED, config.call_status_url, config.call_status_urlType, node, msg),
             method: config.call_status_method
           };
           opts.speech_synthesis_vendor = config.vendor;
@@ -72,7 +72,7 @@ module.exports = function(RED) {
       switch (config.dest) {
         case 'phone':
           if (config.trunk) {
-            var trunk = new_resolve(RED, config.trunk, config.trunkType, node, msg);
+            var trunk = await new_resolve(RED, config.trunk, config.trunkType, node, msg);
             opts.to.trunk = trunk;
           }
           opts.to.number = to;

--- a/src/nodes/create_sms.js
+++ b/src/nodes/create_sms.js
@@ -7,7 +7,7 @@ function create_sms(config) {
     var node = this;
     const server = RED.nodes.getNode(config.server);
 
-    node.on('input', async(msg, send, done) => {
+    node.on('input', async (msg, send, done) => {
       send = send || function() { node.send.apply(node, arguments);};
 
       const {accountSid, apiToken} = server.credentials;
@@ -19,10 +19,10 @@ function create_sms(config) {
         return;
       }
 
-      var from = new_resolve(RED, config.from, config.fromType, node, msg)
-      var to = new_resolve(RED, config.to, config.toType, node, msg)
-      var text = new_resolve(RED, config.text, config.textType, node, msg);
-      var provider = new_resolve(RED, config.provider, config.providerType, node, msg)
+      var from = await new_resolve(RED, config.from, config.fromType, node, msg)
+      var to = await new_resolve(RED, config.to, config.toType, node, msg)
+      var text = await new_resolve(RED, config.text, config.textType, node, msg);
+      var provider = await new_resolve(RED, config.provider, config.providerType, node, msg)
 
       const opts = {
         from,

--- a/src/nodes/dequeue.js
+++ b/src/nodes/dequeue.js
@@ -5,15 +5,15 @@ module.exports = function(RED) {
   function dequeue(config) {
     RED.nodes.createNode(this, config);
     var node = this;
-    node.on('input', function(msg, send, done) {
-      const timeout = new_resolve(RED, config.timeout, config.timeoutType, node, msg);
+    node.on('input', async function(msg, send, done) {
+      const timeout = await new_resolve(RED, config.timeout, config.timeoutType, node, msg);
       appendVerb(msg, {
         verb: 'dequeue',
-        name:  new_resolve(RED, config.queue, config.queueType, node, msg),
-        callSid: new_resolve(RED, config.callSid, config.callSidType, node, msg),
+        name:  await new_resolve(RED, config.queue, config.queueType, node, msg),
+        callSid: await new_resolve(RED, config.callSid, config.callSidType, node, msg),
         beep: config.beep,
-        actionHook: new_resolve(RED, config.actionHook, config.actionHookType, node, msg),
-        confirmHook: new_resolve(RED, config.confirmHook, config.confirmHookType, node, msg),
+        actionHook: await new_resolve(RED, config.actionHook, config.actionHookType, node, msg),
+        confirmHook: await new_resolve(RED, config.confirmHook, config.confirmHookType, node, msg),
         timeout: (/^\d+$/.test(timeout)) ? parseInt(timeout) : null,
       });
       node.send(msg);

--- a/src/nodes/dialogflow.js
+++ b/src/nodes/dialogflow.js
@@ -4,22 +4,22 @@ module.exports = function(RED) {
 function dialogflow(config) {
     RED.nodes.createNode(this, config);
     var node = this;
-    node.on('input', function(msg) {
-      var val = new_resolve(RED, config.inputTimeout, config.inputTimeoutType, node, msg);
+    node.on('input', async function(msg) {
+      var val = await new_resolve(RED, config.inputTimeout, config.inputTimeoutType, node, msg);
       var timeout = /^\d+$/.test(val) ? parseInt(val) : 0;
-      var eventHook = new_resolve(RED, config.eventHook, config.eventHookType, node, msg);
-      var actionHook = new_resolve(RED, config.actionHook, config.actionHookType, node, msg);
-      var welcomeEvent = new_resolve(RED, config.welcomeEvent, config.welcomeEventType, node, msg);
-      var environment = new_resolve(RED, config.environment, config.environmentType, node, msg);
+      var eventHook = await new_resolve(RED, config.eventHook, config.eventHookType, node, msg);
+      var actionHook = await new_resolve(RED, config.actionHook, config.actionHookType, node, msg);
+      var welcomeEvent = await new_resolve(RED, config.welcomeEvent, config.welcomeEventType, node, msg);
+      var environment = await new_resolve(RED, config.environment, config.environmentType, node, msg);
       var welcomeEventParams;
       if (welcomeEvent && welcomeEvent.length > 0) {
-        welcomeEventParams = new_resolve(RED, config.welcomeEventParams, config.welcomeEventParamsType, node, msg);
+        welcomeEventParams = await new_resolve(RED, config.welcomeEventParams, config.welcomeEventParamsType, node, msg);
       }
-      var noInputEvent = new_resolve(RED, config.noinputEvent, config.noinputEventType, node, msg);
+      var noInputEvent = await new_resolve(RED, config.noinputEvent, config.noinputEventType, node, msg);
       const obj = {
         verb: 'dialogflow',
-        credentials:  new_resolve(RED, config.serviceAccountCredentials, config.serviceAccountCredentialsType, node, msg),
-        project:  new_resolve(RED, config.project, config.projectType, node, msg),
+        credentials:  await new_resolve(RED, config.serviceAccountCredentials, config.serviceAccountCredentialsType, node, msg),
+        project:  await new_resolve(RED, config.project, config.projectType, node, msg),
         lang:  config.recognizerlang,
         bargein: config.bargein
       };

--- a/src/nodes/dtmf.js
+++ b/src/nodes/dtmf.js
@@ -4,11 +4,11 @@ module.exports = function(RED) {
   function dtmf(config) {
     RED.nodes.createNode(this, config);
     var node = this;
-    node.on('input', function(msg) {
+    node.on('input', async function(msg) {
       appendVerb(msg,  {
         verb: 'dtmf',
-        dtmf: new_resolve(RED, config.dtmf, config.dtmfType, node, msg),
-        duration: new_resolve(RED, config.duration, config.durationType, node, msg),
+        dtmf: await new_resolve(RED, config.dtmf, config.dtmfType, node, msg),
+        duration: await new_resolve(RED, config.duration, config.durationType, node, msg),
       });
       node.send(msg);
     });

--- a/src/nodes/dub.js
+++ b/src/nodes/dub.js
@@ -6,13 +6,13 @@ module.exports = function(RED) {
     RED.nodes.createNode(this, config);
     var node = this;
 
-    node.on('input', function(msg) {
+    node.on('input', async function(msg) {
       var obj = {
         verb: 'dub',
         action: config.action,
-        track: new_resolve(RED, config.track, config.trackType, node, msg),
-        play: new_resolve(RED, config.play, config.playType, node, msg),
-        say: new_resolve(RED, config.say, config.sayType, node, msg),
+        track: await new_resolve(RED, config.track, config.trackType, node, msg),
+        play: await new_resolve(RED, config.play, config.playType, node, msg),
+        say: await new_resolve(RED, config.say, config.sayType, node, msg),
         loop: config.loop,
         gain: config.gain
       };

--- a/src/nodes/enqueue.js
+++ b/src/nodes/enqueue.js
@@ -5,13 +5,13 @@ module.exports = function(RED) {
   function enqueue(config) {
     RED.nodes.createNode(this, config);
     var node = this;
-    node.on('input', function(msg, send, done) {
+    node.on('input', async function(msg, send, done) {
       appendVerb(msg, {
         verb: 'enqueue',
-        name:  new_resolve(RED, config.queue, config.queueType, node, msg),
-        priority:  new_resolve(RED, config.priority, config.priorityType, node, msg),
-        actionHook: new_resolve(RED, config.actionHook, config.actionHookType, node, msg),
-        waitHook: new_resolve(RED, config.waitHook, config.waitHookType, node, msg)
+        name:  await new_resolve(RED, config.queue, config.queueType, node, msg),
+        priority:  await new_resolve(RED, config.priority, config.priorityType, node, msg),
+        actionHook: await new_resolve(RED, config.actionHook, config.actionHookType, node, msg),
+        waitHook: await new_resolve(RED, config.waitHook, config.waitHookType, node, msg)
       });
       node.send(msg);
     });

--- a/src/nodes/gather.js
+++ b/src/nodes/gather.js
@@ -5,14 +5,14 @@ module.exports = function(RED) {
   function gather(config) {
     RED.nodes.createNode(this, config);
     var node = this;
-    node.on('input', function(msg) {
+    node.on('input', async function(msg) {
 
       // simple properties
       node.log(`config: ${JSON.stringify(config)}`);
 
       var obj = {verb: 'gather', input: []};
-      if (config.actionhook) obj.actionHook = new_resolve(RED, config.actionhook, config.actionhookType, node, msg)
-      if (config.partialresulthook) obj.partialResultHook = new_resolve(RED, config.partialresulthook, config.partialresulthookType, node, msg)
+      if (config.actionhook) obj.actionHook = await new_resolve(RED, config.actionhook, config.actionhookType, node, msg)
+      if (config.partialresulthook) obj.partialResultHook = await new_resolve(RED, config.partialresulthook, config.partialresulthookType, node, msg)
 
       // input
       if (config.speechinput) {
@@ -22,9 +22,9 @@ module.exports = function(RED) {
           language: config.recognizerlang
         };
         if (recognizer.vendor === 'google') {
-          var hints = new_resolve(RED, config.transcriptionhints, config.transcriptionhintsType, node, msg);
-          var altlangs = new_resolve(RED, config.recognizeraltlang, config.recognizeraltlangType, node, msg);
-          var naics = new_resolve(RED, config.naics, config.naicsType, node, msg);
+          var hints = await new_resolve(RED, config.transcriptionhints, config.transcriptionhintsType, node, msg);
+          var altlangs = await new_resolve(RED, config.recognizeraltlang, config.recognizeraltlangType, node, msg);
+          var naics = await new_resolve(RED, config.naics, config.naicsType, node, msg);
           Object.assign(recognizer, {
             profanityFilter: config.profanityfilter,
             hints: hints.length > 0 ?
@@ -37,8 +37,8 @@ module.exports = function(RED) {
           }
         }
         else if (recognizer.vendor === 'aws') {
-          var vocab = new_resolve(RED, config.vocabularyname, config.vocabularynameType, node, msg);
-          var vocabFilter = new_resolve(RED, config.vocabularyfiltername, config.vocabularyfilternameType, node, msg);
+          var vocab = await new_resolve(RED, config.vocabularyname, config.vocabularynameType, node, msg);
+          var vocabFilter = await new_resolve(RED, config.vocabularyfiltername, config.vocabularyfilternameType, node, msg);
           Object.assign(recognizer, {
             vocabularyName: vocab,
             vocabularyFilterName: vocabFilter,
@@ -74,7 +74,7 @@ module.exports = function(RED) {
           });
         }
       }
-      else obj.play = {url: new_resolve(RED, config.playurl, config.playurlType, node, msg)};
+      else obj.play = {url: await new_resolve(RED, config.playurl, config.playurlType, node, msg)};
 
       node.log(`gather: ${JSON.stringify(obj)}`);
 

--- a/src/nodes/get_alerts.js
+++ b/src/nodes/get_alerts.js
@@ -7,11 +7,11 @@ module.exports = function(RED) {
         var node = this;
         const server = RED.nodes.getNode(config.server);
         const {accountSid, apiToken} = server.credentials;
-        node.on('input', async(msg, send, done) => {
+        node.on('input', async (msg, send, done) => {
             const data = {
-                page: new_resolve(RED, config.page, config.pageType, node, msg),
-                count: new_resolve(RED, config.count, config.countType, node, msg),
-                days: new_resolve(RED, config.days, config.daysType, node, msg),
+                page: await new_resolve(RED, config.page, config.pageType, node, msg),
+                count: await new_resolve(RED, config.count, config.countType, node, msg),
+                days: await new_resolve(RED, config.days, config.daysType, node, msg),
             }
             Object.keys(data).forEach((k) => data[k] == null || data[k] == '' && delete data[k]);
             const params = new URLSearchParams(data).toString()           

--- a/src/nodes/get_call.js
+++ b/src/nodes/get_call.js
@@ -8,7 +8,7 @@ module.exports = function (RED) {
     const server = RED.nodes.getNode(config.server);
     const { accountSid, apiToken } = server.credentials;
     node.on("input", async (msg, send, done) => {
-      const callSid = new_resolve(RED, config.callSid, config.callSidType, node, msg);
+      const callSid = await new_resolve(RED, config.callSid, config.callSidType, node, msg);
       if (!callSid) {
         if (done) done(new Error('CallSid empty'));
           else node.error(new Error('CallSid empty'), msg);

--- a/src/nodes/get_calls.js
+++ b/src/nodes/get_calls.js
@@ -9,10 +9,10 @@ module.exports = function (RED) {
     const { accountSid, apiToken } = server.credentials;
     node.on("input", async (msg, send, done) => {
       const data = {
-        direction: new_resolve(RED, config.direction, config.directionType, node, msg),
-        from: new_resolve(RED, config.from, config.fromType, node, msg),
-        to: new_resolve(RED, config.to, config.toType, node, msg),
-        callStatus: new_resolve(RED, config.callStatus, config.callStatusType, node, msg),
+        direction: await new_resolve(RED, config.direction, config.directionType, node, msg),
+        from: await new_resolve(RED, config.from, config.fromType, node, msg),
+        to: await new_resolve(RED, config.to, config.toType, node, msg),
+        callStatus: await new_resolve(RED, config.callStatus, config.callStatusType, node, msg),
       };
       Object.keys(data).forEach(
         (k) => data[k] == null || (data[k] == '' && delete data[k])

--- a/src/nodes/get_recent_calls.js
+++ b/src/nodes/get_recent_calls.js
@@ -7,13 +7,13 @@ module.exports = function(RED) {
         var node = this;
         const server = RED.nodes.getNode(config.server);
         const {accountSid, apiToken} = server.credentials;
-        node.on('input', async(msg, send, done) => {
+        node.on('input', async (msg, send, done) => {
             const data = {
-                direction: new_resolve(RED, config.direction, config.directionType, node, msg),
-                trunk: new_resolve(RED, config.trunk, config.trunkType, node, msg),
-                page: new_resolve(RED, config.page, config.pageType, node, msg),
-                count: new_resolve(RED, config.count, config.countType, node, msg),
-                days: new_resolve(RED, config.days, config.daysType, node, msg),
+                direction: await new_resolve(RED, config.direction, config.directionType, node, msg),
+                trunk: await new_resolve(RED, config.trunk, config.trunkType, node, msg),
+                page: await new_resolve(RED, config.page, config.pageType, node, msg),
+                count: await new_resolve(RED, config.count, config.countType, node, msg),
+                days: await new_resolve(RED, config.days, config.daysType, node, msg),
             }
             Object.keys(data).forEach((k) => data[k] == null || data[k] == '' && delete data[k]);
             const params = new URLSearchParams(data).toString();       

--- a/src/nodes/hangup.js
+++ b/src/nodes/hangup.js
@@ -4,7 +4,7 @@ module.exports = function(RED) {
     function hangup(config) {
         RED.nodes.createNode(this, config);
         var node = this;
-        node.on('input', function(msg) {
+        node.on('input', async function(msg) {
           var data = {
             verb: 'hangup'
           };

--- a/src/nodes/lcc.js
+++ b/src/nodes/lcc.js
@@ -8,12 +8,12 @@ function lcc(config) {
     var node = this;
     const server = RED.nodes.getNode(config.server);
 
-    node.on('input', async(msg, send, done) => {
+    node.on('input', async (msg, send, done) => {
       send = send || function() { node.send.apply(node, arguments);};
 
       const {accountSid, apiToken} = server.credentials;
       const url = server.url;
-      const callSid = new_resolve(RED, config.callSid, config.callSidType, node, msg);
+      const callSid = await new_resolve(RED, config.callSid, config.callSidType, node, msg);
       if (!url || !accountSid || !apiToken || !callSid) {
         node.log(`invalid / missing credentials or callSid, skipping LCC node: ${JSON.stringify(server.credentials)}`);
         send(msg);
@@ -51,14 +51,14 @@ function lcc(config) {
           opts.transcribe_status = 'resume';
           break;
         case 'redirect':
-          opts.call_hook = {url: new_resolve(RED, config.callHook, config.callHookType, node, msg)};
+          opts.call_hook = {url: await new_resolve(RED, config.callHook, config.callHookType, node, msg)};
           if (config.childCallHook) {
-            opts.child_call_hook = {url: new_resolve(RED, config.childCallHook, config.childCallHookType, node, msg)};
+            opts.child_call_hook = {url: await new_resolve(RED, config.childCallHook, config.childCallHookType, node, msg)};
           }
           break;
         case 'hold_conf':
           opts.conf_hold_status = 'hold';
-          opts.wait_hook = {url: new_resolve(RED, config.waitHook, config.waitHookType, node, msg)};
+          opts.wait_hook = {url: await new_resolve(RED, config.waitHook, config.waitHookType, node, msg)};
           break;
         case 'unhold_conf':
           opts.conf_hold_status = 'unhold';
@@ -82,16 +82,16 @@ function lcc(config) {
         case 'sip_request':
           opts.sip_request = { 
             method: config.sipRequestMethod,
-            content_type: new_resolve(RED, config.sipRequestContentType, config.sipRequestContentTypeType, node, msg),
-            content: new_resolve(RED, config.sipRequestBody, config.sipRequestBodyType, node, msg),
-            headers: new_resolve(RED, config.sipRequestHeaders, config.sipRequestHeadersType, node, msg) || {}
+            content_type: await new_resolve(RED, config.sipRequestContentType, config.sipRequestContentTypeType, node, msg),
+            content: await new_resolve(RED, config.sipRequestBody, config.sipRequestBodyType, node, msg),
+            headers: await new_resolve(RED, config.sipRequestHeaders, config.sipRequestHeadersType, node, msg) || {}
           };
           break;
         case 'start_call_recording':
           opts.record = { 
             action: 'startCallRecording',
-            siprecServerURL: new_resolve(RED, config.siprecServerURL, config.siprecServerURLType, node, msg),
-            recordingID: new_resolve(RED, config.recordingID, config.recordingIDType, node, msg) || crypto.randomUUID()
+            siprecServerURL: await new_resolve(RED, config.siprecServerURL, config.siprecServerURLType, node, msg),
+            recordingID: await new_resolve(RED, config.recordingID, config.recordingIDType, node, msg) || crypto.randomUUID()
           };
           // SIPREC headers
           if (config.siprecHeaders) {
@@ -115,12 +115,12 @@ function lcc(config) {
           break;
         case 'send_dtmf':
           opts.dtmf = { 
-            digit: new_resolve(RED, config.dtmfDigit, config.dtmfDigitType, node, msg),
-            duration: new_resolve(RED, config.dtmfDuration, config.dtmfDurationType, node, msg) || '250'
+            digit: await new_resolve(RED, config.dtmfDigit, config.dtmfDigitType, node, msg),
+            duration: await new_resolve(RED, config.dtmfDuration, config.dtmfDurationType, node, msg) || '250'
           };
           break;
         case 'tag':
-            opts.tag = new_resolve(RED, config.tag, config.tagType, node, msg);
+            opts.tag = await new_resolve(RED, config.tag, config.tagType, node, msg);
             break;
         default:
           node.log(`invalid action: ${config.action}`);

--- a/src/nodes/lex.js
+++ b/src/nodes/lex.js
@@ -6,27 +6,27 @@ module.exports = function(RED) {
     RED.nodes.createNode(this, config);
     var node = this;
     const awsCreds = RED.nodes.getNode(config.aws);
-    node.on('input', function(msg) {
+    node.on('input', async function(msg) {
       let accessKey, secretAccessKey;
       if (awsCreds && awsCreds.credentials) {
         accessKey = awsCreds.credentials.accessKey;
         secretAccessKey = awsCreds.credentials.secretAccessKey;
       }
-      var eventHook = new_resolve(RED, config.eventHook, config.eventHookType, node, msg);
-      var actionHook = new_resolve(RED, config.actionHook, config.actionHookType, node, msg);
-      var botId = new_resolve(RED, config.bot, config.botType, node, msg);
-      var botAlias = new_resolve(RED, config.alias, config.aliasType, node, msg);
-      var locale = new_resolve(RED, config.locale, config.localeType, node, msg) || 'en_US';  
-      var val = new_resolve(RED, config.inputTimeout, config.inputTimeoutType, node, msg);
+      var eventHook = await new_resolve(RED, config.eventHook, config.eventHookType, node, msg);
+      var actionHook = await new_resolve(RED, config.actionHook, config.actionHookType, node, msg);
+      var botId = await new_resolve(RED, config.bot, config.botType, node, msg);
+      var botAlias = await new_resolve(RED, config.alias, config.aliasType, node, msg);
+      var locale = await new_resolve(RED, config.locale, config.localeType, node, msg) || 'en_US';  
+      var val = await new_resolve(RED, config.inputTimeout, config.inputTimeoutType, node, msg);
       var timeout = /^\d+$/.test(val) ? parseInt(val) : 0;
       var slots, intentName;
       if (config.specifyIntent) {
-        intentName =  new_resolve(RED, config.intent, config.intentType, node, msg);
+        intentName =  await new_resolve(RED, config.intent, config.intentType, node, msg);
         if (intentName) {
-          slots =  new_resolve(RED, config.slots, config.slotsType, node, msg);
+          slots =  await new_resolve(RED, config.slots, config.slotsType, node, msg);
         }
       }
-      var metadata =  new_resolve(RED, config.metadata, config.metadataType, node, msg);
+      var metadata =  await new_resolve(RED, config.metadata, config.metadataType, node, msg);
 
       const obj = {
         verb: 'lex',

--- a/src/nodes/listen.js
+++ b/src/nodes/listen.js
@@ -4,11 +4,11 @@ module.exports = function(RED) {
   function listen(config) {
     RED.nodes.createNode(this, config);
     var node = this;
-    node.on('input', function(msg) {
+    node.on('input', async function(msg) {
       const obj = {
         verb: 'listen',
-        url: new_resolve(RED, config.url, config.urlType, node, msg),
-        actionHook: new_resolve(RED, config.actionhook, config.actionhookType, node, msg),
+        url: await new_resolve(RED, config.url, config.urlType, node, msg),
+        actionHook: await new_resolve(RED, config.actionhook, config.actionhookType, node, msg),
         finishOnKey: config.finishonkey,
         mixType: config.mixtype,
         playBeep: config.beep,
@@ -17,8 +17,8 @@ module.exports = function(RED) {
         sampleRate: config.sampleRate,
       };
 
-      const authUser = new_resolve(RED, config.authuser, config.authuserType, node, msg);
-      const authPass = new_resolve(RED, config.authpass, config.authpassType, node, msg);
+      const authUser = await new_resolve(RED, config.authuser, config.authuserType, node, msg);
+      const authPass = await new_resolve(RED, config.authpass, config.authpassType, node, msg);
       if (authUser && authPass) {
         obj.wsAuth = {
           username: authUser,
@@ -35,11 +35,11 @@ module.exports = function(RED) {
           diarization: config.diarization
         };
         if (recognizer.vendor === 'google') {
-          var diarizationMin = new_resolve(RED, config.diarizationmin, config.diarizationminType, node, msg);
-          var diarizationMax = new_resolve(RED, config.diarizationmax, config.diarizationmaxType, node, msg);
-          var hints = new_resolve(RED, config.transcriptionhints, config.transcriptionhintsType, node, msg);
-          var altlangs = new_resolve(RED, config.recognizeraltlang, config.recognizeraltlangType, node, msg);
-          var naics = new_resolve(RED, config.naics, config.naicsType, node, msg);
+          var diarizationMin = await new_resolve(RED, config.diarizationmin, config.diarizationminType, node, msg);
+          var diarizationMax = await new_resolve(RED, config.diarizationmax, config.diarizationmaxType, node, msg);
+          var hints = await new_resolve(RED, config.transcriptionhints, config.transcriptionhintsType, node, msg);
+          var altlangs = await new_resolve(RED, config.recognizeraltlang, config.recognizeraltlangType, node, msg);
+          var naics = await new_resolve(RED, config.naics, config.naicsType, node, msg);
           Object.assign(recognizer, {
             profanityFilter: config.profanityfilter,
             hints: hints.length > 0 ?
@@ -60,8 +60,8 @@ module.exports = function(RED) {
           }
         }
         else if (recognizer.vendor === 'aws') {
-          var vocab = new_resolve(RED, config.vocabularyname, config.vocabularynameType, node, msg);
-          var vocabFilter = new_resolve(RED, config.vocabularyfiltername, config.vocabularyfilternameType, node, msg);
+          var vocab = await new_resolve(RED, config.vocabularyname, config.vocabularynameType, node, msg);
+          var vocabFilter = await new_resolve(RED, config.vocabularyfiltername, config.vocabularyfilternameType, node, msg);
           Object.assign(recognizer, {
             vocabularyName: vocab,
             vocabularyFilterName: vocabFilter,
@@ -69,7 +69,7 @@ module.exports = function(RED) {
           });
         }
         obj.transcribe = {
-          transcriptionHook: new_resolve(RED, config.transcriptionhook, config.transcriptionhookType, node, msg),
+          transcriptionHook: await new_resolve(RED, config.transcriptionhook, config.transcriptionhookType, node, msg),
           recognizer
         };
       }
@@ -77,7 +77,7 @@ module.exports = function(RED) {
       if (/^\d+$/.test(config.maxlength)) obj.maxLength = parseInt(config.maxLength);
       if (config.finishonkey.length) obj.finishOnKey = config.finishonkey;
 
-      var data = new_resolve(RED, config.metadata, config.metadataType, node, msg);
+      var data = await new_resolve(RED, config.metadata, config.metadataType, node, msg);
       if (data) obj.metadata = data;
 
       appendVerb(msg, obj);

--- a/src/nodes/message.js
+++ b/src/nodes/message.js
@@ -4,11 +4,11 @@ module.exports = function (RED) {
   function message(config) {
     RED.nodes.createNode(this, config);
     var node = this;
-    node.on("input", function (msg, send, done) {
-      var from = new_resolve(RED, config.from, config.fromType, node, msg);
-      var to =new_resolve(RED, config.to, config.toType, node, msg);
-      var text = new_resolve(RED, config.text, config.textType, node, msg);
-      var provider = new_resolve(RED, config.provider, config.providerType, node, msg);
+    node.on("input", async function(msg, send, done) {
+      var from = await new_resolve(RED, config.from, config.fromType, node, msg);
+      var to = await new_resolve(RED, config.to, config.toType, node, msg);
+      var text = await new_resolve(RED, config.text, config.textType, node, msg);
+      var provider = await new_resolve(RED, config.provider, config.providerType, node, msg);
       if ((!provider || 0 === provider.length) && msg.sms.provider) {
         provider = msg.sms.provider;
       }

--- a/src/nodes/pause.js
+++ b/src/nodes/pause.js
@@ -5,8 +5,8 @@ module.exports = function(RED) {
   function pause(config) {
     RED.nodes.createNode(this, config);
     var node = this;
-    node.on('input', function(msg) {
-      var length = new_resolve(RED, config.len, config.lenType, node, msg);
+    node.on('input', async function(msg) {
+      var length = await new_resolve(RED, config.len, config.lenType, node, msg);
       appendVerb(msg, {
         verb: 'pause',
         length

--- a/src/nodes/play.js
+++ b/src/nodes/play.js
@@ -4,15 +4,15 @@ module.exports = function(RED) {
   function play(config) {
     RED.nodes.createNode(this, config);
     var node = this;
-    node.on('input', function(msg) {
+    node.on('input', async function(msg) {
       appendVerb(msg,  {
         verb: 'play',
-        url: new_resolve(RED, config.url, config.urlType, node, msg),
+        url: await new_resolve(RED, config.url, config.urlType, node, msg),
         earlyMedia: config.early,
         loop: config.loop,
-        timeoutSecs: config.timeout ? new_resolve(RED, config.timeout, config.timeoutType, node, msg) : null,
-        seekOffset: config.offset ? new_resolve(RED, config.offset, config.offsetType, node, msg) : null,
-        actionHook: config.hook ? new_resolve(RED, config.hook, config.hookType, node, msg) : null
+        timeoutSecs: config.timeout ? await new_resolve(RED, config.timeout, config.timeoutType, node, msg) : null,
+        seekOffset: config.offset ? await new_resolve(RED, config.offset, config.offsetType, node, msg) : null,
+        actionHook: config.hook ? await new_resolve(RED, config.hook, config.hookType, node, msg) : null
       });
       node.send(msg);
     });

--- a/src/nodes/rasa.js
+++ b/src/nodes/rasa.js
@@ -4,12 +4,12 @@ module.exports = function(RED) {
     function rasa(config) {
         RED.nodes.createNode(this, config);
         var node = this;
-        node.on('input', function(msg) {
+        node.on('input', async function(msg) {
           obj = {verb: 'rasa'}
-          obj.url = new_resolve(RED, config.url, config.urlType, node, msg);
-          obj.prompt = new_resolve(RED, config.prompt, config.promptType, node, msg);
-          obj.eventHook = new_resolve(RED, config.eventHook, config.eventHookType, node, msg);
-          obj.actionHook = new_resolve(RED, config.actionHook, config.actionHookType, node, msg);
+          obj.url = await new_resolve(RED, config.url, config.urlType, node, msg);
+          obj.prompt = await new_resolve(RED, config.prompt, config.promptType, node, msg);
+          obj.eventHook = await new_resolve(RED, config.eventHook, config.eventHookType, node, msg);
+          obj.actionHook = await new_resolve(RED, config.actionHook, config.actionHookType, node, msg);
           appendVerb(msg, obj);
           node.send(msg);
         });

--- a/src/nodes/redirect.js
+++ b/src/nodes/redirect.js
@@ -5,8 +5,8 @@ module.exports = function(RED) {
   function redirect(config) {
     RED.nodes.createNode(this, config);
     var node = this;
-    node.on('input', function(msg, send, done) {
-      var actionHook = new_resolve(RED, config.hook, config.hookType, node, msg);
+    node.on('input', async function(msg, send, done) {
+      var actionHook = await new_resolve(RED, config.hook, config.hookType, node, msg);
       appendVerb(msg, {
         verb: 'redirect',
         actionHook

--- a/src/nodes/say.js
+++ b/src/nodes/say.js
@@ -9,8 +9,8 @@ module.exports = function(RED) {
     this.loop = config.loop;
     var node = this;
 
-    node.on('input', function(msg) {
-      const text = new_resolve(RED, config.text, 'mustache', node, msg);
+    node.on('input', async function(msg) {
+      const text = await new_resolve(RED, config.text, 'mustache', node, msg);
       var obj = {
         verb: 'say',
         text,

--- a/src/nodes/sip-decline.js
+++ b/src/nodes/sip-decline.js
@@ -5,15 +5,15 @@ module.exports = function(RED) {
   function sip_decline(config) {
     RED.nodes.createNode(this, config);
     var node = this;
-    node.on('input', function(msg) {
-      var status = new_resolve(RED, config.status, config.statusType, node, msg);
-      var reason = new_resolve(RED, config.reason, config.reasonType, node, msg);
+    node.on('input', async function(msg) {
+      var status = await new_resolve(RED, config.status, config.statusType, node, msg);
+      var reason = await new_resolve(RED, config.reason, config.reasonType, node, msg);
       var obj = {
         verb: 'sip:decline',
         status: parseInt(status),
         reason
       }
-      config.headers ? obj.headers = new_resolve(RED, config.headers, config.headersType, node, msg) : null
+      config.headers ? obj.headers = await new_resolve(RED, config.headers, config.headersType, node, msg) : null
       if (typeof obj.headers == 'string'){
         obj.headers = JSON.parse(obj.headers)
       }

--- a/src/nodes/sip-refer.js
+++ b/src/nodes/sip-refer.js
@@ -4,7 +4,7 @@ module.exports = function(RED) {
   function sip_refer(config) {
     RED.nodes.createNode(this, config);
     var node = this;
-    node.on('input', function(msg) {
+    node.on('input', async function(msg) {
       Object.keys(config).forEach(function(key, index) {
         if (config[key] == ''){
           config[key] = false
@@ -12,15 +12,15 @@ module.exports = function(RED) {
       });
       obj = {
         verb: 'sip:refer',
-        referTo: new_resolve(RED, config.referTo, config.referToType, node, msg)
+        referTo: await new_resolve(RED, config.referTo, config.referToType, node, msg)
       }
-      config.headers ? obj.headers = new_resolve(RED, config.headers, config.headersType, node, msg) : null
+      config.headers ? obj.headers = await new_resolve(RED, config.headers, config.headersType, node, msg) : null
       if (typeof obj.headers == 'string'){
         obj.headers = JSON.parse(obj.headers)
       }
-      config.referredBy ? obj.referredBy = new_resolve(RED, config.referredBy, config.referredByType, node, msg) : null
-      config.actionHook ? obj.actionHook = new_resolve(RED, config.actionHook, config.actionHookType, node, msg) : null
-      config.eventHook ? obj.eventHook = new_resolve(RED, config.eventHook, config.eventHookType, node, msg) : null
+      config.referredBy ? obj.referredBy = await new_resolve(RED, config.referredBy, config.referredByType, node, msg) : null
+      config.actionHook ? obj.actionHook = await new_resolve(RED, config.actionHook, config.actionHookType, node, msg) : null
+      config.eventHook ? obj.eventHook = await new_resolve(RED, config.eventHook, config.eventHookType, node, msg) : null
       appendVerb(msg, obj)
       node.send(msg);
     });

--- a/src/nodes/sip-request.js
+++ b/src/nodes/sip-request.js
@@ -5,7 +5,7 @@ module.exports = function(RED) {
   function sip_request(config) {
     RED.nodes.createNode(this, config);
     var node = this;
-    node.on('input', function(msg) {
+    node.on('input', async function(msg) {
       obj = {
         verb: 'sip:request',
         method: config.method
@@ -15,12 +15,12 @@ module.exports = function(RED) {
           config[key] = false
         };
       });
-      config.headers ? obj.headers = new_resolve(RED, config.headers, config.headersType, node, msg) : null
+      config.headers ? obj.headers = await new_resolve(RED, config.headers, config.headersType, node, msg) : null
       if (typeof obj.headers == 'string'){
         obj.headers = JSON.parse(obj.headers)
       }
-      config.body ? obj.body = new_resolve(RED, config.body, config.bodyType, node, msg) : null
-      config.actionHook ? obj.actionHook = new_resolve(RED, config.actionHook, config.actionHookType, node, msg) : null
+      config.body ? obj.body = await new_resolve(RED, config.body, config.bodyType, node, msg) : null
+      config.actionHook ? obj.actionHook = await new_resolve(RED, config.actionHook, config.actionHookType, node, msg) : null
       appendVerb(msg, obj)
       node.send(msg);
     });

--- a/src/nodes/tag.js
+++ b/src/nodes/tag.js
@@ -4,8 +4,8 @@ module.exports = function(RED) {
   function tag(config) {
     RED.nodes.createNode(this, config);
     var node = this;
-    node.on('input', function(msg) {
-      var data = new_resolve(RED, config.data, config.dataType, node, msg);
+    node.on('input', async function(msg) {
+      var data = await new_resolve(RED, config.data, config.dataType, node, msg);
       if (typeof(data) != 'object'){
         data = JSON.parse(data)
       }

--- a/src/nodes/userauth.js
+++ b/src/nodes/userauth.js
@@ -6,17 +6,17 @@ module.exports = function(RED) {
     function userauth(config) {
       RED.nodes.createNode(this, config);
       var node = this;
-      node.on('input', function(msg) {
+      node.on('input', async function(msg) {
         var attemptedAuthentication = false;
         var auth = msg.authRequest;
         var authResponse = {};
         var ha1_string;
         if (config.ha1 && config.ha1.length) {
-          ha1_string = new_resolve(RED, config.ha1, config.ha1Type, node, msg),
+          ha1_string = await new_resolve(RED, config.ha1, config.ha1Type, node, msg),
           attemptedAuthentication = true;
         }
         else if (config.password && config.password.length) {
-          var password = new_resolve(RED, config.password, config.passwordType, node, msg);
+          var password = await new_resolve(RED, config.password, config.passwordType, node, msg);
           var ha1 = createHash('md5');
           ha1.update([auth.username, auth.realm, password].join(':'));
           ha1_string = ha1.digest('hex');
@@ -51,15 +51,15 @@ module.exports = function(RED) {
           if (calculated === auth.response) {
             let grantedExpires = auth.expires;
             if (config.expires && config.expires.length) {
-              const expires = new_resolve(RED, config.expires, config.expiresType, node, msg);
+              const expires = await new_resolve(RED, config.expires, config.expiresType, node, msg);
               if (auth.expires && expires != null) {
                 grantedExpires = Math.min(auth.expires, expires);
               }
             }
-            const application = new_resolve(RED, config.application, config.applicationType, node, msg);
-            const directUser = new_resolve(RED, config.directUser, config.directUserType, node, msg);
-            const directApp = new_resolve(RED, config.directApp, config.directAppType, node, msg);
-            const directQueue = new_resolve(RED, config.directQueue, config.directQueueType, node, msg);
+            const application = await new_resolve(RED, config.application, config.applicationType, node, msg);
+            const directUser = await new_resolve(RED, config.directUser, config.directUserType, node, msg);
+            const directApp = await new_resolve(RED, config.directApp, config.directAppType, node, msg);
+            const directQueue = await new_resolve(RED, config.directQueue, config.directQueueType, node, msg);
             Object.assign(authResponse, {
               status: 'ok',
               expires: grantedExpires != null ? grantedExpires : null,


### PR DESCRIPTION
Node RED engine deprecated calling **evaluateJSONataExpression** without a callback argument, so adding support for it. This is still parcially supported, but not for **jsonata** type.

More here:
https://nodered.jp/blog/2023/09/06/version-3-1-released