### PR TITLE
fix: fix maxLength property parse

### DIFF
--- a/src/nodes/listen.js
+++ b/src/nodes/listen.js
@@ -74,7 +74,7 @@ module.exports = function(RED) {
         };
       }
       if (/^\d+$/.test(config.timeout)) obj.timeout = parseInt(config.timeout);
-      if (/^\d+$/.test(config.maxlength)) obj.maxLength = parseInt(config.maxLength);
+      if (/^\d+$/.test(config.maxlength)) obj.maxLength = parseInt(config.maxlength);
       if (config.finishonkey.length) obj.finishOnKey = config.finishonkey;
 
       var data = await new_resolve(RED, config.metadata, config.metadataType, node, msg);


### PR DESCRIPTION
When using the maxLength property, it is parsed with an error.

![image](https://github.com/user-attachments/assets/045e2631-b6ed-4a5e-bde7-36654338c8af)
