### PR TITLE
fix: preserve target type in dial verb payload

### DIFF
--- a/src/nodes/dial.js
+++ b/src/nodes/dial.js
@@ -8,7 +8,7 @@ module.exports = function(RED) {
     node.on('input', async function(msg) {
       node.log(`dial config: ${JSON.stringify(config)}, msg.call: ${JSON.stringify(msg.call)}`);
       const target = await Promise.all(config.targets.map(async (t) => {
-        const obj = {};
+        const obj = { type: t.type };  // Initialize with type property
         const dest = await new_resolve(RED, t.dest, t.varType, node, msg);
         const trunk = await new_resolve(RED, t.trunk, t.trunkType, node, msg);
         const tenant = t.tenant ? await new_resolve(RED, t.tenant, t.tenantType, node, msg) : '';


### PR DESCRIPTION
## Bug Fix: Preserve target type in dial verb payload

### Issue
After recent changes, the dial verb stopped including the target type in its payload, which prevented proper routing of dial targets.

### Fix
Modified the target object construction to preserve the type field by initializing the object with the type property:
```javascript
const obj = { type: t.type };

### Testing
- Tested with SIP dial target through Node-RED
- Confirmed type is now present in the debug output payload
- Verified proper routing of calls with the fixed type field

### Example Output
```javascript
jambonz: [
    {
        "verb": "dial",
        "target": [
            {
                "type": "sip",
                "sipUri": "sip:XXXXXX@exampledomain.com"
            }
        ],
        "answerOnBridge": true,
        "callerId": "XXXXXXX",
        "anchorMedia": true
    }
]