### PR TITLE
add generic node

### DIFF
--- a/examples/Generic Verb Node.json
+++ b/examples/Generic Verb Node.json
@@ -1,0 +1,124 @@
+[
+    {
+        "id": "5d9a3f1fa6551a9f",
+        "type": "webhook in",
+        "z": "1b97c147228e3829",
+        "name": "",
+        "url": "/call",
+        "method": "post",
+        "x": 100,
+        "y": 220,
+        "wires": [
+            [
+                "e627c4f20ede7606"
+            ]
+        ]
+    },
+    {
+        "id": "1d33431d324d0453",
+        "type": "webhook out",
+        "z": "1b97c147228e3829",
+        "name": "",
+        "x": 1270,
+        "y": 180,
+        "wires": []
+    },
+    {
+        "id": "9bf6ecad5a81a2bf",
+        "type": "debug",
+        "z": "1b97c147228e3829",
+        "name": "debug 18",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "jambonz",
+        "targetType": "msg",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 1260,
+        "y": 280,
+        "wires": []
+    },
+    {
+        "id": "73e79d1cc5ac62d0",
+        "type": "generic",
+        "z": "1b97c147228e3829",
+        "name": "generic - say",
+        "verb": "say",
+        "data": "{\"text\":\"goodbye\"}",
+        "dataType": "json",
+        "x": 1030,
+        "y": 220,
+        "wires": [
+            [
+                "9bf6ecad5a81a2bf",
+                "1d33431d324d0453"
+            ]
+        ]
+    },
+    {
+        "id": "e627c4f20ede7606",
+        "type": "generic",
+        "z": "1b97c147228e3829",
+        "name": "generic - answer",
+        "verb": "answer",
+        "data": "{}",
+        "dataType": "json",
+        "x": 290,
+        "y": 220,
+        "wires": [
+            [
+                "453b7fb4d62ef93e"
+            ]
+        ]
+    },
+    {
+        "id": "453b7fb4d62ef93e",
+        "type": "generic",
+        "z": "1b97c147228e3829",
+        "name": "generic - pause",
+        "verb": "pause",
+        "data": "{\"length\":1}",
+        "dataType": "json",
+        "x": 480,
+        "y": 220,
+        "wires": [
+            [
+                "da2ac5d1cd9ab0a5"
+            ]
+        ]
+    },
+    {
+        "id": "da2ac5d1cd9ab0a5",
+        "type": "generic",
+        "z": "1b97c147228e3829",
+        "name": "generic -say",
+        "verb": "say",
+        "data": "{\"text\":\"Please hold\",\"loop\":1,\"earlyMedia\":false}",
+        "dataType": "json",
+        "x": 670,
+        "y": 220,
+        "wires": [
+            [
+                "b7225263b1115bde"
+            ]
+        ]
+    },
+    {
+        "id": "b7225263b1115bde",
+        "type": "generic",
+        "z": "1b97c147228e3829",
+        "name": "generic - pause",
+        "verb": "pause",
+        "data": "{\"length\":5}",
+        "dataType": "json",
+        "x": 840,
+        "y": 220,
+        "wires": [
+            [
+                "73e79d1cc5ac62d0"
+            ]
+        ]
+    }
+]

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
       "get_calls": "src/nodes/get_calls.js",
       "get_recent_calls": "src/nodes/get_recent_calls.js",
       "answer": "src/nodes/answer.js",
-      "dub": "src/nodes/dub.js"
+      "dub": "src/nodes/dub.js",
+      "generic": "src/nodes/generic-verb.js"
     }
   },
   "author": "Dave Horton",

--- a/src/nodes/generic-verb.html
+++ b/src/nodes/generic-verb.html
@@ -1,0 +1,60 @@
+<!-- Javascript -->
+<script type="text/javascript">
+ 
+
+  RED.nodes.registerType('generic',{
+      category: 'jambonz',
+      color: '#bbabaa',
+      defaults: {
+        name: {value: ''},
+        verb: {required: true},
+        data: {value: '{}'},
+        dataType: {value: 'json'},
+      },
+      inputs:1,
+      outputs:1,
+      icon: "font-awesome/fa-cubes",
+      label: function() { return this.name || 'generic';},
+      oneditprepare: function() {
+        $('#node-input-data').typedInput({
+          default: $('#node-input-dataType').val(),
+          types: ['json','msg', 'flow', 'global', 'jsonata', 'env'],
+          typeField: $('#node-input-dataType')
+        });
+      }
+  });
+</script>
+
+<!-- HTML -->
+<script type="text/html" data-template-name="generic">
+    <div class="form-row">
+      <label for="node-input-name"><i class="icon-tag"></i> Name</label>
+      <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+    <div class="form-row">
+      <label for="node-input-verb">Verb</label>
+      <input type="text" id="node-input-verb" placeholder="verb">
+    </div>
+    <div class="form-row">
+      <label for="node-input-data">Duration</label>
+      <input type="text" id="node-input-data">
+      <input type="hidden" id="node-input-dataType">
+    </div>
+</script>
+
+<!-- Help Text -->
+<script type="text/html" data-help-name="generic">
+  <p>A generic node to set any verb</p>
+  <h3>Outputs</h3>
+  <dl class="message-properties">
+    <dt>jambonz<span class="property-type">object</span></dt>
+    <dd> <code>msg.jambonz</code> will contain any previous actions provided to the input with the new <code>pause</code> action appended  </dd>
+  </dl>
+  
+  <h3>Details</h3>
+  Allows use of complex or new verbs in Jambonz that may not have nodes, set the verb name and then pass any additional parameters as a JSON object in the data field.
+  <h3>References</h3>
+    <ul>
+        <li><a href="https://www.jambonz.org/docs/webhooks/">Jambonz Verb reference</a></li>
+    </ul>
+</script>

--- a/src/nodes/generic-verb.html
+++ b/src/nodes/generic-verb.html
@@ -36,7 +36,7 @@
       <input type="text" id="node-input-verb" placeholder="verb">
     </div>
     <div class="form-row">
-      <label for="node-input-data">Duration</label>
+      <label for="node-input-data">Attributes</label>
       <input type="text" id="node-input-data">
       <input type="hidden" id="node-input-dataType">
     </div>
@@ -52,7 +52,7 @@
   </dl>
   
   <h3>Details</h3>
-  Allows use of complex or new verbs in Jambonz that may not have nodes, set the verb name and then pass any additional parameters as a JSON object in the data field.
+  Allows use of complex or new verbs in Jambonz that may not have nodes, set the verb name and then pass any additional attributes as a JSON object in the data field.
   <h3>References</h3>
     <ul>
         <li><a href="https://www.jambonz.org/docs/webhooks/">Jambonz Verb reference</a></li>

--- a/src/nodes/generic-verb.js
+++ b/src/nodes/generic-verb.js
@@ -1,0 +1,18 @@
+var {appendVerb, new_resolve} = require('./libs')
+
+module.exports = function(RED) {
+  function generic(config) {
+    RED.nodes.createNode(this, config);
+    var node = this;
+    node.verb = config.verb
+    node.on('input', async function(msg) {
+      let data = await new_resolve(RED, config.data, config.dataType, node, msg);
+      appendVerb(msg, {
+        ...{verb: node.verb}, 
+        ...data
+      });
+      node.send(msg);
+    });
+  }
+  RED.nodes.registerType('generic', generic);
+}


### PR DESCRIPTION
This adds a new node, a generic verb.

This is to allow for use of Node-RED with new or edge case features that are implemented in Jambonz but not (yet) in Node-RED.
You can specify the verb as a config string and then the associated attributes of it as a JSON object (or typed input)

This doesn't replace the need to update Node-RED with new Jambonz features but should help more savvy users that want to use the full featureset of jambonz.