### PR TITLE
LLC: support canceling calls

### DIFF
--- a/src/nodes/lcc.html
+++ b/src/nodes/lcc.html
@@ -355,7 +355,8 @@
   <div class="form-row">
     <label for="node-input-action">Action</label>
     <select id="node-input-action">
-      <option value="hangup">hangup call</option>
+      <option value="hangup">hangup answered call</option>
+      <option value="cancel">cancel call</option>
       <option value="mute">mute caller</option>
       <option value="unmute">unmute caller</option>
       <option value="mute_conf">mute conference participants</option>

--- a/src/nodes/lcc.js
+++ b/src/nodes/lcc.js
@@ -26,6 +26,9 @@ function lcc(config) {
         case 'hangup':
           opts.call_status = 'completed';
           break;
+        case 'cancel':
+          opts.call_status = 'no-answer';
+          break;
         case 'mute':
           opts.mute_status = 'mute';
           break;


### PR DESCRIPTION
At this moment there are no ways to terminate a call that is not answered. So adding ability to send a cancel message into a session.

The core logic is here:
https://github.com/jambonz/jambonz-feature-server/blob/31e6997746dd1be74f33915168006ce10157883e/lib/session/call-session.js#L1330