### PR TITLE
feat: add typed input support for dial verb SIP header values

### DIFF
--- a/src/nodes/dial.html
+++ b/src/nodes/dial.html
@@ -373,7 +373,7 @@
           addItem: function(container, i, opt) {
             var header = opt;
             if (!header.hasOwnProperty('h')) {
-                header = {h: '', v: ''};
+                header = {h: '', v: '', vType: 'str'};
             }
             container.css({
               overflow: 'hidden',
@@ -382,20 +382,23 @@
             let fragment = document.createDocumentFragment();
             var row1 = $('<div/>',{style:"display:flex;"}).appendTo(fragment);
             $('<input/>', {
-              class:"node-input-header-property-name", 
-              type:"text", 
+              class:"node-input-header-property-name",
+              type:"text",
               placeholder: 'SIP Header'
             })
               .appendTo(row1);
             $('<input/>', {
-              class:"node-input-value-property-name", 
-              type:"text", 
+              class:"node-input-value-property-name",
+              type:"text",
               placeholder: 'value'
             })
-              .appendTo(row1);
+              .appendTo(row1)
+              .typedInput({types: ['str', 'msg', 'flow', 'global', 'jsonata', 'env', mustacheType]});
 
             row1.find('.node-input-header-property-name').val(header.h);
-            row1.find('.node-input-value-property-name').val(header.v);
+            var valueField = row1.find('.node-input-value-property-name');
+            valueField.typedInput('type', header.vType || 'str');
+            valueField.typedInput('value', header.v);
 
             container[0].appendChild(fragment);
           },
@@ -406,6 +409,7 @@
           var header = {
             h: '',
             v: '',
+            vType: 'str'
           };
           this.headers = [header];
         }
@@ -457,11 +461,13 @@
           var header = $(this);
           console.log(`header: ${JSON.stringify(header)}`);
           var h = header.find(".node-input-header-property-name").val();
-          var v = header.find(".node-input-value-property-name").val();
-          console.log(`added ${h}: ${v}`);
+          var vField = header.find(".node-input-value-property-name");
+          var v = vField.typedInput('value');
+          var vType = vField.typedInput('type');
+          console.log(`added ${h}: ${v} (type: ${vType})`);
           var obj = {};
           obj[h] = v;
-          headers.push({h, v});
+          headers.push({h, v, vType});
         });
         node.headers = headers;
         console.log(`saved headers ${JSON.stringify(node.headers)}`);

--- a/src/nodes/dial.js
+++ b/src/nodes/dial.js
@@ -74,9 +74,12 @@ module.exports = function(RED) {
 
       // headers
       const headers = {};
-      config.headers.forEach(function(h) {
-        if (h.h.length && h.v.length) headers[h.h] = h.v;
-      });
+      for (const h of config.headers) {
+        if (h.h.length && h.v.length) {
+          const resolvedValue = await new_resolve(RED, h.v, h.vType || 'str', node, msg);
+          if (resolvedValue) headers[h.h] = resolvedValue;
+        }
+      }
       Object.assign(data, {headers});
 
       // nested listen


### PR DESCRIPTION
## Summary
Add support for dynamic header values in the dial verb by implementing typed inputs for the SIP headers value field.

## Changes
- Updated `dial.html` to add typedInput widget for header values with support for multiple input types
- Added `vType` field to track the input type for each header (string, msg, flow, global, jsonata, env, mustache)
- Modified `dial.js` to resolve header values dynamically using `new_resolve()`
- Maintains backward compatibility with existing static header values

## Benefits
This enhancement provides greater flexibility for setting dynamic SIP headers based on:
- Message properties (`msg.`)
- Flow context (`flow.`)
- Global context (`global.`)
- JSONata expressions
- Environment variables
- Mustache templates

## Backward Compatibility
Existing dial nodes with static header values will continue to work without modification. The `vType` field defaults to `'str'` for backward compatibility.

## Testing
Tested with Node-RED and confirmed that:
- New dial nodes can set headers using all supported input types
- Existing dial nodes with static headers continue to function correctly
- Header values are properly resolved at runtime